### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-PyDP is a Python wrapper for Google's [Differencial Privacy](https://github.com/google/differential-privacy) project. The library provides a set of ε-differentially private algorithms, which can be used to produce aggregate statistics over numeric data sets containing private or sensitive information.
+PyDP is a Python wrapper for Google's [Differential Privacy](https://github.com/google/differential-privacy) project. The library provides a set of ε-differentially private algorithms, which can be used to produce aggregate statistics over numeric data sets containing private or sensitive information.
 
 PyDP is part of the OpenMined community, come join the movement on [Slack](http://slack.openmined.org/).
 


### PR DESCRIPTION
## Description

* 'Differential' was wrongly spelled as 'Differencial' in the README. **I simply fixed this minor spelling mistake**
* Motivation is that this gives a better initial impression for this project
* No dependencies are required for this change